### PR TITLE
Fix/form update options

### DIFF
--- a/docs/reference/react/useForm.md
+++ b/docs/reference/react/useForm.md
@@ -12,7 +12,7 @@ declare function useForm<
   TData,
   TAdapter extends ValidatorAdapter | undefined = undefined,
 >(
-  options: FormLogicOptions<TData, TAdapter>,
+  options?: FormLogicOptions<TData, TAdapter>,
 ): FormContextType<TData, TAdapter>;
 ```
 

--- a/packages/form-core/src/FormLogic.spec.ts
+++ b/packages/form-core/src/FormLogic.spec.ts
@@ -473,12 +473,15 @@ describe('FormLogic', () => {
       form.updateOptions({ defaultValues: { name: 'another' } })
       expect(form.data.value.name.value).toBe('another')
     })
-    it("should be able to remove fields of dynamic objects or items from an array when updating the options", () =>{
-      const form = new FormLogic<{ obj: { [key: string]: string }, array: number[] }>({
+    it('should be able to remove fields of dynamic objects or items from an array when updating the options', () => {
+      const form = new FormLogic<{
+        obj: { [key: string]: string }
+        array: number[]
+      }>({
         defaultValues: {
           obj: {
-            stay: "stay",
-            go: "go"
+            stay: 'stay',
+            go: 'go',
           },
           array: [1, 2, 3],
         },
@@ -487,18 +490,23 @@ describe('FormLogic', () => {
 
       expect(form.json.value).toEqual({
         obj: {
-          stay: "stay",
-          go: "go"
+          stay: 'stay',
+          go: 'go',
         },
-        array: [1, 2, 3]
+        array: [1, 2, 3],
       })
-      form.updateOptions({ defaultValues: { obj: {stay: "stay(changed)", new: "new"}, array: [2] } })
+      form.updateOptions({
+        defaultValues: {
+          obj: { stay: 'stay(changed)', new: 'new' },
+          array: [2],
+        },
+      })
       expect(form.json.value).toEqual({
         obj: {
-          stay: "stay(changed)",
-          new: "new"
+          stay: 'stay(changed)',
+          new: 'new',
         },
-        array: [2]
+        array: [2],
       })
     })
 
@@ -1835,7 +1843,7 @@ describe('FormLogic', () => {
         expect(form.data.value.deep.value.new.value).toBe(2)
         expect(fn).toHaveBeenCalledTimes(1)
       })
-      it("should touch a field when adding a new key to an object if configured", () => {
+      it('should touch a field when adding a new key to an object if configured', () => {
         const form = new FormLogic<{ deep: { [key: string]: number } }>({
           defaultValues: {
             deep: {
@@ -1928,7 +1936,7 @@ describe('FormLogic', () => {
         expect(form.data.value.deep.value.value).toBeUndefined()
         expect(fn).toHaveBeenCalledTimes(1)
       })
-      it("should touch a field when removing a key from an object if configured", () => {
+      it('should touch a field when removing a key from an object if configured', () => {
         const form = new FormLogic<{ deep: { value?: number } }>({
           defaultValues: {
             deep: {

--- a/packages/form-core/src/FormLogic.ts
+++ b/packages/form-core/src/FormLogic.ts
@@ -27,7 +27,6 @@ import {
   isEqualDeep,
   makeArrayEntry,
   removeSignalValueAtPath,
-  removeValueAtPath,
   setSignalValueAtPath,
   setSignalValuesFromObject,
   setValueAtPath,
@@ -394,9 +393,9 @@ export class FormLogic<
     // We do not want to update dirty field values, since we do not want to reset the form, but just override the default values
     const newDefaultValues = { ...options.defaultValues }
     for (const dirtyField of dirtyFields) {
-      removeValueAtPath(newDefaultValues, dirtyField as never)
+      setValueAtPath(newDefaultValues, dirtyField as never, undefined)
     }
-    setSignalValuesFromObject(this._data, newDefaultValues, true)
+    setSignalValuesFromObject(this._data, newDefaultValues)
   }
 
   /**

--- a/packages/form-react/src/form/form.hooks.tsx
+++ b/packages/form-react/src/form/form.hooks.tsx
@@ -22,7 +22,7 @@ export function useForm<
   TData,
   TAdapter extends ValidatorAdapter | undefined = undefined,
 >(
-  options: FormLogicOptions<TData, TAdapter>,
+  options?: FormLogicOptions<TData, TAdapter>,
 ): FormContextType<TData, TAdapter> {
   // biome-ignore lint/correctness/useExhaustiveDependencies: We only ever want to create a form once
   const finalForm = React.useMemo(() => {


### PR DESCRIPTION
# Pull Request Template

| Key                      | Value                                                                       |
|--------------------------|-----------------------------------------------------------------------------|
| **Status**               | Done                           |
| **Related Issues**       | -                                         |
| **Description**          | Fixing incorrect behaviour of `form.updateSignals` |
| **Type of change**       | Bug fix                      |
| **Is a breaking change** | No                                                                  |

## TODO

- [x] Own review of the code
- [x] All tests are passing
- [x] The code is well documented
- [x] The documentation website is up-to-date
- [x] Tests cover new code or fixes

## Changes

When updating the options of a form, it was not possible to remove array items or dynamic object keys when passing new default values.
If there was an array with an item, the item would persist when passing an array without any items.