### PR TITLE
feat(form-core): keep unmounted values by default

### DIFF
--- a/docs/guide/react/basic-usage.md
+++ b/docs/guide/react/basic-usage.md
@@ -214,10 +214,8 @@ export default function MyForm() {
 
 Once a field is created, it will be automatically mounted with the provided name and options.
 If the component is unmounted, so will the field.
-By default, this will also remove all the state of this field and remove the value from the form.
-
-If you want to hide the field temporarily and keep its value and state,
-you can use the `preserveValueOnUnmount` option when creating the field.
+By default, this will keep all the state of this field.
+If you want to remove the values of the field, you can use the `removeValueOnUnmount` option, which will reset the state and remove values of a field once it unmounts.
 
 ```tsx {10}
 export default function MyForm() {
@@ -229,7 +227,7 @@ export default function MyForm() {
       {showAge && (
         <form.FieldProvider
           name="age"
-          preserveValueOnUnmount
+          removeValueOnUnmount
         >
           {(field) => (
             <InputSignal value={field.data}/>
@@ -252,10 +250,7 @@ export default function MyForm() {
 
   return (
     <form.FormProvider>
-      <form.FieldProvider
-        name={fieldName}
-        preserveValueOnUnmount
-      >
+      <form.FieldProvider name={fieldName}>
         {(field) => (
           <InputSignal value={field.data}/>
         )}
@@ -267,8 +262,7 @@ export default function MyForm() {
 ```
 
 ::: warning
-If you do not use the `preserveValueOnUnmount` option,
-the value of the field will be lost when the field name is changed.
+Using the `removeValueOnUnmount` option, might cause some unexpected issues, so be careful using this.
 :::
 
 ## Tips
@@ -283,7 +277,6 @@ That way, you can avoid unnecessary re-renders of parent components.
 
 ```tsx
 import {Signal} from "@preact/signals-react";
-import ex = CSS.ex;
 
 interface InputSignalProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> {
   value: Signal<string>;
@@ -305,7 +298,7 @@ import {useFieldContext} from "@formsignals/form-react";
 
 export function ErrorText() {
   const field = useFieldContext();
-  if (!field.isValid.value) return null;
+  if (field.isValid.value) return null;
   return <span>{field.errors.value.join(", ")}</span>
 }
 ```

--- a/docs/guide/react/quickstart.md
+++ b/docs/guide/react/quickstart.md
@@ -151,7 +151,7 @@ export default function App() {
 }
 ```
 
-```tsx [SignalInput.tsx]
+```tsx [FormInput.tsx]
 import type {Signal} from '@preact/signals-react'
 import type {InputHTMLAttributes} from 'react'
 

--- a/docs/reference/core/FieldLogic.md
+++ b/docs/reference/core/FieldLogic.md
@@ -94,7 +94,7 @@ type FieldLogicOptions<
     errors?: Partial<ValidationErrorMap>
   }
 
-  preserveValueOnUnmount?: boolean
+  removeValueOnUnmount?: boolean
   resetValueToDefaultOnUnmount?: boolean
 
   transformFromBinding?: (value: TBoundValue) => ValueAtPath<TData, TName>
@@ -102,22 +102,22 @@ type FieldLogicOptions<
 }
 ```
 
-| Option                         | Description                                                                                                                                                                                  |
-|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `disabled`                     | If set to `true`, the field will be disabled.                                                                                                                                                |
-| `validatorAdapter`             | The validation adapter to use for this field. If not set, the field falls back to the form's validation adapter. <br/>Reference the [Validation API](/reference/core/Validation#adapter).    |
-| `validator`                    | The synchronous validation function. If the field has a validation adapter, this can be a schema. <br/>Reference the [Validation API](/reference/core/Validation#adapter).                   |
-| `validatorOptions`             | The options for the synchronous validation function. <br/>Reference the [Validation API](/reference/core/Validation#adapter).                                                                |
-| `validatorAsync`               | The asynchronous validation function. If the field has a validation adapter, this can be a schema. <br/>Reference the [Validation API](/reference/core/Validation#adapter).                  |
-| `validatorAsyncOptions`        | The options for the asynchronous validation function. <br/>Reference the [Validation API](/reference/core/Validation#adapter).                                                               |
-| `validateOnNestedChange`       | If set to `true`, the field will validate when a nested value changes. <br/>Reference the [Basic Usage](/guide/validation#deep-validation).                                                  |
-| `validateMixin`                | The paths of the values used for the validation mixin. <br/>Reference the [Basic Usage](/guide/validation#validation-mixins).                                                                |
-| `defaultValue`                 | The default value of the field.                                                                                                                                                              |
-| `defaultState`                 | The default state of the field. There you can set default errors and the touched state.                                                                                                      |
-| `preserveValueOnUnmount`       | If set to `true`, the value of the field will be preserved when the field is unmounted.                                                                                                      |
-| `resetValueToDefaultOnUnmount` | If set to `true`, the value of the field will be reset to the default value when the field is unmounted.                                                                                     |
-| `transformFromBinding`         | The function to transform the value from the binding. <br/>Reference the [Basic Usage](/guide/basic-usage#add-transformation)                                                                |
-| `transformToBinding`           | The function to transform the value to the binding. <br/>Reference the [Basic Usage](/guide/basic-usage#add-transformation)                                                                  |
+| Option                         | Description                                                                                                                                                                               |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `disabled`                     | If set to `true`, the field will be disabled.                                                                                                                                             |
+| `validatorAdapter`             | The validation adapter to use for this field. If not set, the field falls back to the form's validation adapter. <br/>Reference the [Validation API](/reference/core/Validation#adapter). |
+| `validator`                    | The synchronous validation function. If the field has a validation adapter, this can be a schema. <br/>Reference the [Validation API](/reference/core/Validation#adapter).                |
+| `validatorOptions`             | The options for the synchronous validation function. <br/>Reference the [Validation API](/reference/core/Validation#adapter).                                                             |
+| `validatorAsync`               | The asynchronous validation function. If the field has a validation adapter, this can be a schema. <br/>Reference the [Validation API](/reference/core/Validation#adapter).               |
+| `validatorAsyncOptions`        | The options for the asynchronous validation function. <br/>Reference the [Validation API](/reference/core/Validation#adapter).                                                            |
+| `validateOnNestedChange`       | If set to `true`, the field will validate when a nested value changes. <br/>Reference the [Basic Usage](/guide/validation#deep-validation).                                               |
+| `validateMixin`                | The paths of the values used for the validation mixin. <br/>Reference the [Basic Usage](/guide/validation#validation-mixins).                                                             |
+| `defaultValue`                 | The default value of the field.                                                                                                                                                           |
+| `defaultState`                 | The default state of the field. There you can set default errors and the touched state.                                                                                                   |
+| `removeValueOnUnmount`         | If set to `true`, the value of the field will be removed when the field is unmounted.                                                                                                     |
+| `resetValueToDefaultOnUnmount` | If set to `true`, the value of the field will be reset to the default value when the field is unmounted.                                                                                  |
+| `transformFromBinding`         | The function to transform the value from the binding. <br/>Reference the [Basic Usage](/guide/basic-usage#add-transformation)                                                             |
+| `transformToBinding`           | The function to transform the value to the binding. <br/>Reference the [Basic Usage](/guide/basic-usage#add-transformation)                                                               |
 
 ## Field State
 

--- a/examples/react/complex-product-details-form-signals/src/components/form/PriceTable.tsx
+++ b/examples/react/complex-product-details-form-signals/src/components/form/PriceTable.tsx
@@ -96,7 +96,6 @@ export const PriceTable = () => {
           <form.FieldProvider
             name={`prices.${selectedCurrency.value}`}
             defaultValue={[]}
-            preserveValueOnUnmount
           >
             <PriceTableBody />
           </form.FieldProvider>

--- a/examples/react/complex-product-details-form-signals/src/components/form/VariantCreator.tsx
+++ b/examples/react/complex-product-details-form-signals/src/components/form/VariantCreator.tsx
@@ -77,7 +77,6 @@ const VariantTab = ({ index }: { index: number }) => {
     <>
       <field.SubFieldProvider
         name={`${index}.name`}
-        preserveValueOnUnmount
         validator={z.string().min(1, 'Name is required')}
         validatorOptions={{
           validateOnMount: true,
@@ -110,7 +109,6 @@ const VariantTab = ({ index }: { index: number }) => {
         <div className="flex flex-col gap-1">
           <field.SubFieldProvider
             name={`${index}.options`}
-            preserveValueOnUnmount
             validator={z
               .array(z.string())
               .min(1, 'At least one option is required')}
@@ -148,11 +146,7 @@ const VariantOptionsList = ({
   const parentField = useFieldContext<Product, `variants.${number}.options`>()
 
   return parentField.data.value.map((option, optionIndex) => (
-    <parentField.SubFieldProvider
-      key={option.key}
-      name={`${optionIndex}`}
-      preserveValueOnUnmount
-    >
+    <parentField.SubFieldProvider key={option.key} name={`${optionIndex}`}>
       {(field) => (
         <InputSignal
           type="text"

--- a/packages/dev-tools-react/src/FormDevTools.spec.tsx
+++ b/packages/dev-tools-react/src/FormDevTools.spec.tsx
@@ -815,6 +815,7 @@ describe('FormDevTools', () => {
 
     const field = form.getOrCreateField('name', {
       defaultValue: 'John',
+      removeValueOnUnmount: true,
     })
     await field.mount()
     field.unmount()
@@ -850,7 +851,6 @@ describe('FormDevTools', () => {
 
     const field = form.getOrCreateField('name', {
       defaultValue: 'John',
-      preserveValueOnUnmount: true,
     })
     await field.mount()
     field.unmount()

--- a/packages/form-core/src/FieldGroupLogic.spec.ts
+++ b/packages/form-core/src/FieldGroupLogic.spec.ts
@@ -116,7 +116,9 @@ describe('FieldGroupLogic', () => {
     })
     it('should loose a field once it is unmounted without preserving its value', () => {
       const form = new FormLogic<{ name: string }>()
-      const field = new FieldLogic(form, 'name')
+      const field = new FieldLogic(form, 'name', {
+        removeValueOnUnmount: true,
+      })
       field.mount()
       const group = form.getOrCreateFieldGroup(['name'])
       expect(group.fields.peek().length).toBe(1)
@@ -126,9 +128,7 @@ describe('FieldGroupLogic', () => {
     })
     it('should keep a field once it is unmounted if preserving its value', () => {
       const form = new FormLogic<{ name: string }>()
-      const field = new FieldLogic(form, 'name', {
-        preserveValueOnUnmount: true,
-      })
+      const field = new FieldLogic(form, 'name')
       field.mount()
       const group = form.getOrCreateFieldGroup(['name'])
       expect(group.fields.peek().length).toBe(1)

--- a/packages/form-core/src/FieldLogic.spec.ts
+++ b/packages/form-core/src/FieldLogic.spec.ts
@@ -1199,7 +1199,6 @@ describe('FieldLogic', () => {
       const form = new FormLogic<{ name: string }>()
       form.mount()
       const field = new FieldLogic(form, 'name', {
-        preserveValueOnUnmount: true,
         validator: (value) => (value === 'test' ? undefined : 'error'),
       })
       field.mount()
@@ -1213,6 +1212,7 @@ describe('FieldLogic', () => {
       form.mount()
       const field = new FieldLogic(form, 'name', {
         validator: (value) => (value === 'test' ? undefined : 'error'),
+        removeValueOnUnmount: true,
       })
       field.mount()
       field.data.value = 'test'
@@ -1757,7 +1757,9 @@ describe('FieldLogic', () => {
     it('should remove child fields from form if parent is unmounted', () => {
       const form = new FormLogic<{ parent: { child: number } }>()
       form.mount()
-      const field = new FieldLogic(form, 'parent')
+      const field = new FieldLogic(form, 'parent', {
+        removeValueOnUnmount: true,
+      })
       field.mount()
       const child = new FieldLogic(form, 'parent.child')
       child.mount()
@@ -1788,7 +1790,7 @@ describe('FieldLogic', () => {
       expect(form.data.value.name.value).toBe('default')
       expect(field.isTouched.value).toBe(false)
     })
-    it('should delete field state on unmount if not otherwise configured', () => {
+    it('should delete field state on unmount if not configured', () => {
       const form = new FormLogic<{ name: string }>({
         defaultValues: {
           name: 'default',
@@ -1796,7 +1798,9 @@ describe('FieldLogic', () => {
       })
       form.mount()
 
-      const field = new FieldLogic(form, 'name')
+      const field = new FieldLogic(form, 'name', {
+        removeValueOnUnmount: true,
+      })
       field.mount()
       field.handleBlur()
       field.data.value = 'value'
@@ -1816,9 +1820,7 @@ describe('FieldLogic', () => {
       })
       form.mount()
 
-      const field = new FieldLogic(form, 'name', {
-        preserveValueOnUnmount: true,
-      })
+      const field = new FieldLogic(form, 'name')
       field.mount()
       field.handleBlur()
       field.handleChange('value')
@@ -1838,9 +1840,7 @@ describe('FieldLogic', () => {
       })
       form.mount()
 
-      const field = new FieldLogic(form, 'name', {
-        preserveValueOnUnmount: true,
-      })
+      const field = new FieldLogic(form, 'name')
       field.mount()
       field.handleBlur()
       field.pushValueToArray('value')
@@ -1879,7 +1879,9 @@ describe('FieldLogic', () => {
     it('should not accept value changes through its handlers when unmounted', () => {
       const form = new FormLogic<{ name: string }>()
       form.mount()
-      const field = new FieldLogic(form, 'name')
+      const field = new FieldLogic(form, 'name', {
+        removeValueOnUnmount: true,
+      })
       field.mount()
       field.unmount()
 

--- a/packages/form-core/src/FormLogic.spec.ts
+++ b/packages/form-core/src/FormLogic.spec.ts
@@ -84,7 +84,9 @@ describe('FormLogic', () => {
     })
     it('should loose a field once it is unmounted without preserving its value', () => {
       const form = new FormLogic<{ name: string }>()
-      const field = new FieldLogic(form, 'name')
+      const field = new FieldLogic(form, 'name', {
+        removeValueOnUnmount: true,
+      })
       field.mount()
       expect(form.fields.peek().length).toBe(1)
 
@@ -93,9 +95,7 @@ describe('FormLogic', () => {
     })
     it('should keep a field once it is unmounted if preserving its value', () => {
       const form = new FormLogic<{ name: string }>()
-      const field = new FieldLogic(form, 'name', {
-        preserveValueOnUnmount: true,
-      })
+      const field = new FieldLogic(form, 'name')
       field.mount()
       expect(form.fields.peek().length).toBe(1)
 
@@ -227,7 +227,9 @@ describe('FormLogic', () => {
       expect(form.isTouched.value).toBe(false)
       expect(form.isDirty.value).toBe(false)
 
-      const newField = new FieldLogic(form, 'other')
+      const newField = new FieldLogic(form, 'other', {
+        removeValueOnUnmount: true,
+      })
       newField.mount()
 
       newField.handleBlur()
@@ -252,9 +254,7 @@ describe('FormLogic', () => {
       expect(form.isTouched.value).toBe(false)
       expect(form.isDirty.value).toBe(false)
 
-      const newField = new FieldLogic(form, 'other', {
-        preserveValueOnUnmount: true,
-      })
+      const newField = new FieldLogic(form, 'other')
       newField.mount()
 
       newField.handleBlur()
@@ -280,7 +280,9 @@ describe('FormLogic', () => {
       expect(form.isTouched.value).toBe(false)
       expect(form.isDirty.value).toBe(false)
 
-      const newField = new FieldLogic(form, 'other')
+      const newField = new FieldLogic(form, 'other', {
+        removeValueOnUnmount: true,
+      })
       newField.mount()
 
       newField.handleBlur()
@@ -389,7 +391,6 @@ describe('FormLogic', () => {
       const form = new FormLogic<{ name: string }>()
       await form.mount()
       const field = new FieldLogic(form, 'name', {
-        preserveValueOnUnmount: true,
         validator: () => 'error',
         validatorOptions: {
           validateOnMount: true,
@@ -410,6 +411,7 @@ describe('FormLogic', () => {
       const form = new FormLogic<{ name: string }>()
       await form.mount()
       const field = new FieldLogic(form, 'name', {
+        removeValueOnUnmount: true,
         validator: () => 'error',
         validatorOptions: {
           validateOnMount: true,
@@ -1038,7 +1040,6 @@ describe('FormLogic', () => {
       })
       form.mount()
       const field = new FieldLogic(form, 'name', {
-        preserveValueOnUnmount: true,
         validator: () => 'error',
       })
       field.mount()
@@ -1063,6 +1064,7 @@ describe('FormLogic', () => {
       form.mount()
       const field = new FieldLogic(form, 'name', {
         validator: () => 'error',
+        removeValueOnUnmount: true,
       })
       field.mount()
 

--- a/packages/form-react/src/TestComponent.tsx
+++ b/packages/form-react/src/TestComponent.tsx
@@ -57,11 +57,7 @@ function List() {
     <>
       <ul>
         {field.data.value.map((value, index) => (
-          <field.SubFieldProvider
-            key={value.key}
-            name={`${index}`}
-            preserveValueOnUnmount
-          >
+          <field.SubFieldProvider key={value.key} name={`${index}`}>
             <ListItem />
           </field.SubFieldProvider>
         ))}

--- a/packages/form-react/src/field/field.hooks.spec.tsx
+++ b/packages/form-react/src/field/field.hooks.spec.tsx
@@ -29,6 +29,7 @@ describe('Field hooks', () => {
 
       function MyComponent() {
         const field = useField(form, 'name', {
+          removeValueOnUnmount: true,
           defaultValue: 'John',
         })
         return <div>{field.data.value}</div>
@@ -74,6 +75,7 @@ describe('Field hooks', () => {
       function MyComponent({ name }: { name: 'name' | 'otherName' }) {
         useField(form, name, {
           defaultValue: 'set',
+          removeValueOnUnmount: true,
         })
         return null
       }

--- a/packages/form-react/src/field/field.provider.spec.tsx
+++ b/packages/form-react/src/field/field.provider.spec.tsx
@@ -132,8 +132,8 @@ describe('FieldProvider', () => {
       )
 
       expect(screen.getByText('default')).toBeDefined()
-      expect(form.fields.value.length).toBe(1)
-      expect(form.json.value).toEqual({ other: 'default' })
+      expect(form.fields.value.length).toBe(2)
+      expect(form.json.value).toEqual({ name: 'default', other: 'default' })
 
       cleanup()
     })
@@ -249,6 +249,7 @@ describe('FieldProvider', () => {
             parentField={parentFieldContext}
             name={name}
             defaultValue="default"
+            removeValueOnUnmount
           >
             {(field) => field.data.value}
           </SubField>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,7 +513,7 @@ importers:
   packages/dev-tools-react:
     dependencies:
       '@formsignals/form-react':
-        specifier: ^0.2.0
+        specifier: ^0.2.1
         version: link:../form-react
       '@preact/signals-react':
         specifier: ^2.0.0


### PR DESCRIPTION
# Pull Request Template

| Key                      | Value                                                                       |
|--------------------------|-----------------------------------------------------------------------------|
| **Status**               | Done                           |
| **Related Issues**       | -                                         |
| **Description**          | Keep the values and state of a field by default when it unmounts. |
| **Type of change**       | Feature                      |
| **Is a breaking change** | Yes                                                                  |

## TODO

- [x] Own review of the code
- [x] All tests are passing
- [x] The code is well documented
- [x] The documentation website is up-to-date
- [x] Tests cover new code or fixes
