### PR TITLE
fix/array default override

### DIFF
--- a/packages/form-core/src/FieldGroupLogic.spec.ts
+++ b/packages/form-core/src/FieldGroupLogic.spec.ts
@@ -1374,6 +1374,7 @@ describe('FieldGroupLogic', () => {
         expect(field.errors.value).toEqual(['error'])
         expect(group.isDirty.value).toBe(true)
         expect(group.dirtyFields.value).toEqual([
+          'array',
           'array.1',
           'deep.value',
           'name',

--- a/packages/form-core/src/FormLogic.spec.ts
+++ b/packages/form-core/src/FormLogic.spec.ts
@@ -533,7 +533,7 @@ describe('FormLogic', () => {
         array: [2],
       })
     })
-    it("should not update the defaultValue of an array when updating the options", async () => {
+    it('should not update the defaultValue of an array when updating the options', async () => {
       const form = new FormLogic<{ array: number[] }>({
         defaultValues: {
           array: [1, 2, 3],

--- a/packages/form-core/src/FormLogic.spec.ts
+++ b/packages/form-core/src/FormLogic.spec.ts
@@ -533,6 +533,18 @@ describe('FormLogic', () => {
         array: [2],
       })
     })
+    it("should not update the defaultValue of an array when updating the options", async () => {
+      const form = new FormLogic<{ array: number[] }>({
+        defaultValues: {
+          array: [1, 2, 3],
+        },
+      })
+      await form.mount()
+
+      form.handleChange('array', [4, 5])
+      form.updateOptions({ defaultValues: { array: [1, 2, 3] } })
+      expect(form.json.value.array).toEqual([4, 5])
+    })
 
     it('should update the data when using the handleChange method', () => {
       const form = new FormLogic<{ name: string }>()
@@ -1645,6 +1657,7 @@ describe('FormLogic', () => {
         expect(form.dirtyFields.value).toEqual([
           'name',
           'deep.value',
+          'array',
           'array.1',
         ])
         expect(form.submitCount.value).toBe(1)

--- a/packages/form-core/src/utils/equality.utils.spec.ts
+++ b/packages/form-core/src/utils/equality.utils.spec.ts
@@ -63,10 +63,6 @@ describe('equality.utils', () => {
       [{}, {}],
       [{ a: 1 }, { a: 1 }],
       [
-        { a: 1, b: { c: 2 } },
-        { a: 1, b: { c: 2, d: 3 } },
-      ],
-      [
         { nestedArray: [1, undefined, null, new Date(0)] },
         { nestedArray: [1, undefined, null, new Date(0)] },
       ],
@@ -76,11 +72,6 @@ describe('equality.utils', () => {
         expect(getLeftUnequalPaths(a, b)).toEqual([])
       },
     )
-    it('should not report additional keys from right object', () => {
-      expect(getLeftUnequalPaths({ a: 1, b: 2 }, { a: 1, b: 2, c: 3 })).toEqual(
-        [],
-      )
-    })
     it.each([
       [1, 2, ['']],
       [null, undefined, ['']],
@@ -113,6 +104,7 @@ describe('equality.utils', () => {
         },
         [
           'nestedArray.3',
+          'nestedArray.4.deeply.nested',
           'nestedArray.4.deeply.nested.0',
           'nestedArray.4.deeply.nested.1',
           'nestedArray.5',

--- a/packages/form-core/src/utils/equality.utils.ts
+++ b/packages/form-core/src/utils/equality.utils.ts
@@ -71,6 +71,12 @@ function getLeftUnequalPathsInternal(
   const aNonNullable = a as NonNullable<unknown>
   const bNonNullable = b as NonNullable<unknown>
   const aKeys = Object.keys(aNonNullable)
+  const bKeys = Object.keys(bNonNullable)
+
+  // In this case we do not want to return, since an object can both be dirty and have dirty children
+  if (aKeys.length !== bKeys.length) {
+    internalAcc = [...internalAcc, currentKey]
+  }
 
   for (const key of aKeys) {
     const nextKey = currentKey ? `${currentKey}.${key}` : key


### PR DESCRIPTION
…ng values

# Pull Request Template

| Key                      | Value                                                                       |
|--------------------------|-----------------------------------------------------------------------------|
| **Status**               | Done                           |
| **Related Issues**       |                                          |
| **Description**          | The array field was not marked as dirty when fields where removed or added, so the default values would be overriden when setting them to an array of a different length |
| **Type of change**       | Bug fix                      |
| **Is a breaking change** | No                                                                  |

## TODO

- [x] Own review of the code
- [x] All tests are passing
- [x] The code is well documented
- [x] The documentation website is up-to-date
- [x] Tests cover new code or fixes
