### PR TITLE
fix(form-react): allow to manage mounted state by a different source …

### DIFF
--- a/packages/form-react/src/field-group/field-group.hooks.spec.tsx
+++ b/packages/form-react/src/field-group/field-group.hooks.spec.tsx
@@ -87,6 +87,23 @@ describe('Field Group hooks', () => {
 
       cleanup()
     })
+    it('should not unmount the group if it was mounted from another source', () => {
+      const form = new FormLogic<{ name: string }>()
+      const group = form.getOrCreateFieldGroup(['name'])
+      group.mount()
+
+      function MyComponent() {
+        useFieldGroup(form, ['name'])
+        return null
+      }
+
+      const screen = render(<MyComponent />)
+      expect(group.isMounted.value).toBeTruthy()
+      screen.unmount()
+      expect(group.isMounted.value).toBeTruthy()
+
+      cleanup()
+    })
   })
   describe('useFieldGroupWithComponents', () => {
     it('should return the field group context from the provided field group logic', () => {

--- a/packages/form-react/src/field-group/field-group.hooks.tsx
+++ b/packages/form-react/src/field-group/field-group.hooks.tsx
@@ -77,6 +77,8 @@ export function useFieldGroup<
   }, [group, options])
 
   useIsomorphicLayoutEffect(() => {
+    // In this case the groups mounted state is managed by another owner
+    if (group.isMounted.peek()) return
     group.mount()
     return () => {
       group.unmount()

--- a/packages/form-react/src/field/field.hooks.spec.tsx
+++ b/packages/form-react/src/field/field.hooks.spec.tsx
@@ -96,6 +96,25 @@ describe('Field hooks', () => {
 
       cleanup()
     })
+    it('should not unmount the field if it was mounted from another source', () => {
+      const form = new FormLogic<{ name: string }>()
+      const field = form.getOrCreateField('name')
+      field.mount()
+
+      function MyComponent() {
+        useField(form, 'name', {
+          defaultValue: 'John',
+        })
+        return null
+      }
+
+      const screen = render(<MyComponent />)
+      expect(field.isMounted.value).toBeTruthy()
+      screen.unmount()
+      expect(field.isMounted.value).toBeTruthy()
+
+      cleanup()
+    })
   })
   describe('useFieldWithComponents', () => {
     it('should return the field context from the provided field logic', () => {

--- a/packages/form-react/src/field/field.hooks.tsx
+++ b/packages/form-react/src/field/field.hooks.tsx
@@ -54,6 +54,8 @@ export function useField<
   }, [field, options])
 
   useIsomorphicLayoutEffect(() => {
+    // In this case the fields mounted state is managed by another owner
+    if (field.isMounted.peek()) return
     field.mount()
     return () => {
       field.unmount()


### PR DESCRIPTION
…than the hooks

# Pull Request Template

| Key                      | Value                                                                       |
|--------------------------|-----------------------------------------------------------------------------|
| **Status**               | Done                           |
| **Related Issues**       |                                          |
| **Description**          | Previously a field would always unmount when used with the hook, but now if the field was mounted previously, the hook will not handle the fields unmounting. |
| **Type of change**       | Bug fix                      |
| **Is a breaking change** | No                                                                  |

## TODO

- [x] Own review of the code
- [x] All tests are passing
- [x] The code is well documented
- [x] The documentation website is up-to-date
- [x] Tests cover new code or fixes
