### PR TITLE
Fix React form-signal examples for StackBlitz

### DIFF
--- a/examples/react/async-form-signals/package.json
+++ b/examples/react/async-form-signals/package.json
@@ -7,10 +7,10 @@
     "example": "vite"
   },
   "dependencies": {
-    "@formsignals/dev-tools-react": "workspace:^",
-    "@formsignals/form-core": "workspace:^",
-    "@formsignals/form-react": "workspace:^",
-    "@formsignals/validation-adapter-zod": "workspace:^",
+    "@formsignals/dev-tools-react": "^0.4.2",
+    "@formsignals/form-core": "^0.4.2",
+    "@formsignals/form-react": "^0.4.2",
+    "@formsignals/validation-adapter-zod": "^0.4.2",
     "@preact/signals-react": "^2.2.0",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.1",

--- a/examples/react/complex-product-details-form-signals/package.json
+++ b/examples/react/complex-product-details-form-signals/package.json
@@ -7,10 +7,10 @@
     "example": "vite"
   },
   "dependencies": {
-    "@formsignals/dev-tools-react": "workspace:^",
-    "@formsignals/form-core": "workspace:^",
-    "@formsignals/form-react": "workspace:^",
-    "@formsignals/validation-adapter-zod": "workspace:^",
+    "@formsignals/dev-tools-react": "^0.4.2",
+    "@formsignals/form-core": "^0.4.2",
+    "@formsignals/form-react": "^0.4.2",
+    "@formsignals/validation-adapter-zod": "^0.4.2",
     "@preact/signals-react": "^2.2.0",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.1",

--- a/examples/react/e-commerce-form-signals/package.json
+++ b/examples/react/e-commerce-form-signals/package.json
@@ -7,10 +7,10 @@
     "example": "vite"
   },
   "dependencies": {
-    "@formsignals/dev-tools-react": "workspace:^",
-    "@formsignals/form-core": "workspace:^",
-    "@formsignals/form-react": "workspace:^",
-    "@formsignals/validation-adapter-zod": "workspace:^",
+    "@formsignals/dev-tools-react": "^0.4.2",
+    "@formsignals/form-core": "^0.4.2",
+    "@formsignals/form-react": "^0.4.2",
+    "@formsignals/validation-adapter-zod": "^0.4.2",
     "@preact/signals-react": "^2.2.0",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.1",

--- a/examples/react/files-form-signals/package.json
+++ b/examples/react/files-form-signals/package.json
@@ -7,10 +7,10 @@
     "example": "vite"
   },
   "dependencies": {
-    "@formsignals/dev-tools-react": "workspace:^",
-    "@formsignals/form-core": "workspace:^",
-    "@formsignals/form-react": "workspace:^",
-    "@formsignals/validation-adapter-zod": "workspace:^",
+    "@formsignals/dev-tools-react": "^0.4.2",
+    "@formsignals/form-core": "^0.4.2",
+    "@formsignals/form-react": "^0.4.2",
+    "@formsignals/validation-adapter-zod": "^0.4.2",
     "@preact/signals-react": "^2.2.0",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.1",

--- a/examples/react/performance-test-form-signals/package.json
+++ b/examples/react/performance-test-form-signals/package.json
@@ -7,10 +7,10 @@
     "example": "vite"
   },
   "dependencies": {
-    "@formsignals/dev-tools-react": "workspace:^",
-    "@formsignals/form-core": "workspace:^",
-    "@formsignals/form-react": "workspace:^",
-    "@formsignals/validation-adapter-zod": "workspace:^",
+    "@formsignals/dev-tools-react": "^0.4.2",
+    "@formsignals/form-core": "^0.4.2",
+    "@formsignals/form-react": "^0.4.2",
+    "@formsignals/validation-adapter-zod": "^0.4.2",
     "@preact/signals-react": "^2.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/examples/react/simple-form-signals/package.json
+++ b/examples/react/simple-form-signals/package.json
@@ -7,8 +7,8 @@
     "example": "vite"
   },
   "dependencies": {
-    "@formsignals/form-core": "workspace:^",
-    "@formsignals/form-react": "workspace:^",
+    "@formsignals/form-core": "^0.4.2",
+    "@formsignals/form-react": "^0.4.2",
     "@preact/signals-react": "^2.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/react/step-wizard-form-signals/package.json
+++ b/examples/react/step-wizard-form-signals/package.json
@@ -7,10 +7,10 @@
     "example": "vite"
   },
   "dependencies": {
-    "@formsignals/dev-tools-react": "workspace:^",
-    "@formsignals/form-core": "workspace:^",
-    "@formsignals/form-react": "workspace:^",
-    "@formsignals/validation-adapter-zod": "workspace:^",
+    "@formsignals/dev-tools-react": "^0.4.2",
+    "@formsignals/form-core": "^0.4.2",
+    "@formsignals/form-react": "^0.4.2",
+    "@formsignals/validation-adapter-zod": "^0.4.2",
     "@preact/signals-react": "^2.2.0",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,16 +51,16 @@ importers:
   examples/react/async-form-signals:
     dependencies:
       '@formsignals/dev-tools-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/dev-tools-react
       '@formsignals/form-core':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-core
       '@formsignals/form-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-react
       '@formsignals/validation-adapter-zod':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/validation-adapter-zod
       '@preact/signals-react':
         specifier: ^2.2.0
@@ -175,16 +175,16 @@ importers:
   examples/react/complex-product-details-form-signals:
     dependencies:
       '@formsignals/dev-tools-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/dev-tools-react
       '@formsignals/form-core':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-core
       '@formsignals/form-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-react
       '@formsignals/validation-adapter-zod':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/validation-adapter-zod
       '@preact/signals-react':
         specifier: ^2.2.0
@@ -508,16 +508,16 @@ importers:
   examples/react/e-commerce-form-signals:
     dependencies:
       '@formsignals/dev-tools-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/dev-tools-react
       '@formsignals/form-core':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-core
       '@formsignals/form-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-react
       '@formsignals/validation-adapter-zod':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/validation-adapter-zod
       '@preact/signals-react':
         specifier: ^2.2.0
@@ -632,16 +632,16 @@ importers:
   examples/react/files-form-signals:
     dependencies:
       '@formsignals/dev-tools-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/dev-tools-react
       '@formsignals/form-core':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-core
       '@formsignals/form-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-react
       '@formsignals/validation-adapter-zod':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/validation-adapter-zod
       '@preact/signals-react':
         specifier: ^2.2.0
@@ -756,16 +756,16 @@ importers:
   examples/react/performance-test-form-signals:
     dependencies:
       '@formsignals/dev-tools-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/dev-tools-react
       '@formsignals/form-core':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-core
       '@formsignals/form-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-react
       '@formsignals/validation-adapter-zod':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/validation-adapter-zod
       '@preact/signals-react':
         specifier: ^2.2.0
@@ -817,10 +817,10 @@ importers:
   examples/react/simple-form-signals:
     dependencies:
       '@formsignals/form-core':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-core
       '@formsignals/form-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-react
       '@preact/signals-react':
         specifier: ^2.2.0
@@ -854,16 +854,16 @@ importers:
   examples/react/step-wizard-form-signals:
     dependencies:
       '@formsignals/dev-tools-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/dev-tools-react
       '@formsignals/form-core':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-core
       '@formsignals/form-react':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/form-react
       '@formsignals/validation-adapter-zod':
-        specifier: workspace:^
+        specifier: ^0.4.2
         version: link:../../../packages/validation-adapter-zod
       '@preact/signals-react':
         specifier: ^2.2.0


### PR DESCRIPTION
| Key                      | Value                                                                       |
|--------------------------|-----------------------------------------------------------------------------|
| **Status**               | Ready for Review                           |
| **Related Issues**       | n/a                                      |
| **Description**          | Set the version of the form-signal packages in all React examples for StackBlitz. It was set to workspace before|
| **Type of change**       | Bug fix                       |
| **Is a breaking change** |  No                                                                  |

## TODO

- [x] Own review of the code
- [x] All tests are passing
- [x] The code is well documented
- [x] The documentation website is up-to-date
- [ ] Tests cover new code or fixes

## Changes

Replaced `workspace^` versions with explicit npm versions.
