### PR TITLE
Fix/step wizard no unmounted errors

### DIFF
--- a/docs/reference/core/FieldLogic.md
+++ b/docs/reference/core/FieldLogic.md
@@ -96,6 +96,7 @@ type FieldLogicOptions<
 
   removeValueOnUnmount?: boolean
   resetValueToDefaultOnUnmount?: boolean
+  keepInFormOnUnmount?: boolean
 
   transformFromBinding?: (value: TBoundValue) => ValueAtPath<TData, TName> | [ValueAtPath<TData, TName>, ValidationError]
   transformToBinding?: (value: ValueAtPath<TData, TName>, isValid: boolean, writeBuffer?: TBoundValue) => TBoundValue
@@ -116,6 +117,7 @@ type FieldLogicOptions<
 | `defaultState`                 | The default state of the field. There you can set default errors and the touched state.                                                                                                   |
 | `removeValueOnUnmount`         | If set to `true`, the value of the field will be removed when the field is unmounted.                                                                                                     |
 | `resetValueToDefaultOnUnmount` | If set to `true`, the value of the field will be reset to the default value when the field is unmounted.                                                                                  |
+| `keepInFormOnUnmount`          | If set to `true`, the field will stay in the form when unmounted.                                                                                                                         |
 | `transformFromBinding`         | The function to transform the value from the binding. <br/>Reference the [Basic Usage](/guide/basic-usage#add-transformation)                                                             |
 | `transformToBinding`           | The function to transform the value to the binding. <br/>Reference the [Basic Usage](/guide/basic-usage#add-transformation)                                                               |
 

--- a/examples/react/step-wizard-form-signals/src/components/stepper/AccountStep.tsx
+++ b/examples/react/step-wizard-form-signals/src/components/stepper/AccountStep.tsx
@@ -47,6 +47,7 @@ export const AccountStep = (props: PersonalStepProps) => {
             name="username"
             validator={z.string().min(3)}
             validatorOptions={{ validateOnChangeIfTouched: true }}
+            keepInFormOnUnmount
           >
             <div className="flex-1">
               <Label>Username</Label>
@@ -58,6 +59,7 @@ export const AccountStep = (props: PersonalStepProps) => {
             name="password"
             validator={z.string().min(8)}
             validatorOptions={{ validateOnChangeIfTouched: true }}
+            keepInFormOnUnmount
           >
             <div className="flex-1">
               <Label>Password</Label>
@@ -72,6 +74,7 @@ export const AccountStep = (props: PersonalStepProps) => {
             }
             validateMixin={['password']}
             validatorOptions={{ validateOnChangeIfTouched: true }}
+            keepInFormOnUnmount
           >
             <div className="flex-1">
               <Label>Confirm Password</Label>

--- a/examples/react/step-wizard-form-signals/src/components/stepper/AddressStep.tsx
+++ b/examples/react/step-wizard-form-signals/src/components/stepper/AddressStep.tsx
@@ -50,14 +50,22 @@ export const AddressStep = (props: PersonalStepProps) => {
         </CardHeader>
 
         <CardContent>
-          <group.FieldProvider name="street" validator={z.string().min(1)}>
+          <group.FieldProvider
+            name="street"
+            validator={z.string().min(1)}
+            keepInFormOnUnmount
+          >
             <div className="flex-1">
               <Label>Street</Label>
               <InputForm placeholder="Type here..." />
               <ErrorText />
             </div>
           </group.FieldProvider>
-          <group.FieldProvider name="city" validator={z.string().min(1)}>
+          <group.FieldProvider
+            name="city"
+            validator={z.string().min(1)}
+            keepInFormOnUnmount
+          >
             <div className="flex-1">
               <Label>City</Label>
               <InputForm placeholder="Type here..." />
@@ -65,14 +73,22 @@ export const AddressStep = (props: PersonalStepProps) => {
             </div>
           </group.FieldProvider>
           <div className="mb-1.5 flex flex-row gap-2">
-            <group.FieldProvider name="zip" validator={z.string().min(1)}>
+            <group.FieldProvider
+              name="zip"
+              validator={z.string().min(1)}
+              keepInFormOnUnmount
+            >
               <div className="flex-1">
                 <Label>Postal Code</Label>
                 <InputForm placeholder="Type here..." />
                 <ErrorText />
               </div>
             </group.FieldProvider>
-            <group.FieldProvider name="state" validator={z.string().min(1)}>
+            <group.FieldProvider
+              name="state"
+              validator={z.string().min(1)}
+              keepInFormOnUnmount
+            >
               <div className="flex-[5]">
                 <Label>State</Label>
                 <InputForm placeholder="Type here..." />
@@ -84,6 +100,7 @@ export const AddressStep = (props: PersonalStepProps) => {
             name="country"
             validator={z.string()}
             defaultValue="USA"
+            keepInFormOnUnmount
           >
             {(field) => (
               <div>

--- a/examples/react/step-wizard-form-signals/src/components/stepper/PersonalStep.tsx
+++ b/examples/react/step-wizard-form-signals/src/components/stepper/PersonalStep.tsx
@@ -45,14 +45,22 @@ export const PersonalStep = (props: PersonalStepProps) => {
 
         <CardContent>
           <div className="mb-1.5 flex flex-row gap-2">
-            <group.FieldProvider name="firstName" validator={z.string().min(1)}>
+            <group.FieldProvider
+              name="firstName"
+              validator={z.string().min(1)}
+              keepInFormOnUnmount
+            >
               <div className="flex-1">
                 <Label>First Name</Label>
                 <InputForm placeholder="Type here..." />
                 <ErrorText />
               </div>
             </group.FieldProvider>
-            <group.FieldProvider name="lastName" validator={z.string().min(1)}>
+            <group.FieldProvider
+              name="lastName"
+              validator={z.string().min(1)}
+              keepInFormOnUnmount
+            >
               <div className="flex-1">
                 <Label>Last Name</Label>
                 <InputForm placeholder="Type here..." />
@@ -60,7 +68,11 @@ export const PersonalStep = (props: PersonalStepProps) => {
               </div>
             </group.FieldProvider>
           </div>
-          <group.FieldProvider name="dateOfBirth" validator={z.date()}>
+          <group.FieldProvider
+            name="dateOfBirth"
+            validator={z.date()}
+            keepInFormOnUnmount
+          >
             {(field) => (
               <div className="flex flex-1 flex-col gap-1">
                 <Label htmlFor={field.name}>Date of Birth</Label>
@@ -78,6 +90,7 @@ export const PersonalStep = (props: PersonalStepProps) => {
             name="email"
             validator={z.string().email().min(1)}
             validatorOptions={{ validateOnChangeIfTouched: true }}
+            keepInFormOnUnmount
           >
             <div className="flex-1">
               <Label>Email</Label>
@@ -85,7 +98,11 @@ export const PersonalStep = (props: PersonalStepProps) => {
               <ErrorText />
             </div>
           </group.FieldProvider>
-          <group.FieldProvider name="phone" validator={z.string().optional()}>
+          <group.FieldProvider
+            name="phone"
+            validator={z.string().optional()}
+            keepInFormOnUnmount
+          >
             <div className="flex-1">
               <Label>Phone</Label>
               <InputForm placeholder="Type here..." />

--- a/examples/react/step-wizard-form-signals/src/components/stepper/PreferencesStep.tsx
+++ b/examples/react/step-wizard-form-signals/src/components/stepper/PreferencesStep.tsx
@@ -53,7 +53,6 @@ export const PreferencesStep = (props: PersonalStepProps) => {
           <group.FieldProvider
             name="contact"
             validator={([value, email, phone]) => {
-              console.log('validate', value, email, phone)
               if (value === 'email' && !email)
                 return 'Email is required for this contact method'
               if (value === 'phone' && !phone)
@@ -64,6 +63,7 @@ export const PreferencesStep = (props: PersonalStepProps) => {
             }}
             defaultValue="email"
             validateMixin={['email', 'phone']}
+            keepInFormOnUnmount
           >
             {(field) => (
               <div>
@@ -86,6 +86,7 @@ export const PreferencesStep = (props: PersonalStepProps) => {
             name="language"
             validator={z.string()}
             defaultValue="english"
+            keepInFormOnUnmount
           >
             {(field) => (
               <div>
@@ -107,6 +108,7 @@ export const PreferencesStep = (props: PersonalStepProps) => {
             name="newsletter"
             validator={z.boolean()}
             defaultValue={false}
+            keepInFormOnUnmount
           >
             <Label className="items-top mt-2 flex gap-2">
               <CheckboxForm className="h-5 w-5 rounded" />

--- a/packages/form-core/src/FieldLogic.ts
+++ b/packages/form-core/src/FieldLogic.ts
@@ -149,6 +149,11 @@ export type FieldLogicOptions<
    * If true, the field value will set to its default value.
    */
   resetValueToDefaultOnUnmount?: boolean
+  /**
+   * Whenever a field is unmounted, the field is removed from the form.
+   * If true, the field will stay in the form.
+   */
+  keepInFormOnUnmount?: boolean
 
   /**
    * This takes the value provided by the binding and transforms it to the value that should be set in the form.
@@ -572,6 +577,7 @@ export class FieldLogic<
       this.defaultValue.peek(),
       this._options.peek()?.removeValueOnUnmount,
       this._options.peek()?.resetValueToDefaultOnUnmount,
+      this._options.peek()?.keepInFormOnUnmount,
     )
   }
 

--- a/packages/form-core/src/FormLogic.spec.ts
+++ b/packages/form-core/src/FormLogic.spec.ts
@@ -1213,6 +1213,40 @@ describe('FormLogic', () => {
       await form.handleSubmit()
       expect(field.errors.value).toEqual([])
     })
+    it('should validate unmounted fields if they are kept, only for the submit event', async () => {
+      const form = new FormLogic<{ name: string }>({
+        defaultValues: {
+          name: 'default',
+        },
+      })
+      await form.mount()
+      const field = new FieldLogic(form, 'name', {
+        validator: () => 'error',
+        keepInFormOnUnmount: true,
+      })
+      await field.mount()
+
+      field.unmount()
+      await form.handleSubmit()
+      expect(field.errors.value).toEqual(['error'])
+    })
+    it("should not validate unmounted fields if they are kept, for any event other than 'onSubmit'", async () => {
+      const form = new FormLogic<{ name: string }>({
+        defaultValues: {
+          name: 'default',
+        },
+      })
+      await form.mount()
+      const field = new FieldLogic(form, 'name', {
+        validator: () => 'error',
+        keepInFormOnUnmount: true,
+      })
+      await field.mount()
+
+      field.unmount()
+      form.data.value.name.value = "asd"
+      expect(field.errors.value).toEqual([])
+    })
   })
   describe('handleSubmit', () => {
     it('should not handle submit if the form is invalid', () => {

--- a/packages/form-core/src/FormLogic.spec.ts
+++ b/packages/form-core/src/FormLogic.spec.ts
@@ -1244,7 +1244,7 @@ describe('FormLogic', () => {
       await field.mount()
 
       field.unmount()
-      form.data.value.name.value = "asd"
+      form.data.value.name.value = 'asd'
       expect(field.errors.value).toEqual([])
     })
   })


### PR DESCRIPTION
# Pull Request Template

| Key                      | Value                                                                       |
|--------------------------|-----------------------------------------------------------------------------|
| **Status**               | Done                           |
| **Related Issues**       | -                                         |
| **Description**          | Add the possibility of keeping fields in form on unmount for step wizard examples. |
| **Type of change**       | Bug fix                       |
| **Is a breaking change** | No                                                                  |

## TODO

- [x] Own review of the code
- [x] All tests are passing
- [x] The code is well documented
- [x] The documentation website is up-to-date
- [x] Tests cover new code or fixes

## Changes

Added new option `keepInFormOnUnmount` for fields to keep them on a form after unmounting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `keepInFormOnUnmount` option to enhance field state management during component unmounting.
	- Updated multiple form components to retain field values for `username`, `password`, `confirmPassword`, `street`, `city`, `zip`, `state`, `firstName`, `lastName`, `dateOfBirth`, `email`, `phone`, `contact`, `language`, and `newsletter` fields.

- **Bug Fixes**
	- Improved validation behavior for unmounted fields during form submission.

- **Tests**
	- Added new test cases to verify validation of unmounted fields in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->