### PR TITLE
Add 'Open with Codeanywhere' badge to README.md

### DIFF
--- a/examples/react/e-commerce-form-signals/README.md
+++ b/examples/react/e-commerce-form-signals/README.md
@@ -3,6 +3,7 @@
 This is an example application that demonstrates how to use the `form-signals` library to create a form outside a component and include it in different locations through a global import.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/gutentag2012/form-signals/tree/main/examples/react/e-commerce-form-signals?startScript=example&title=Form%20Signals%20&#124;%20E-Commerce%20Example)
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/gutentag2012/form-signals)
 
 ## Quick Start
 


### PR DESCRIPTION
With Codeanywhere, developers and contributors can instantly launch a cloud or local IDE with a pre-configured remote development environment. One can work in the cloud or locally, and it ensures all contributors have access to the same, ready-to-use dev env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an "Open in Codeanywhere" image link to the README for the E-Commerce Form Signals example, providing users with an alternative platform to access the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->